### PR TITLE
Make an HTTPS request instead of just HTTP

### DIFF
--- a/spec/external_request_spec.rb
+++ b/spec/external_request_spec.rb
@@ -10,11 +10,8 @@ describe 'External request', :vcr => true do
 
   def do_request(uri)
     http = Net::HTTP.new(uri.host, uri.port)
-    http.use_ssl = true
-    http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-
+    http.use_ssl = uri.scheme == 'https'
     request = Net::HTTP::Get.new(uri.request_uri)
-
     http.request(request)
   end
 end

--- a/spec/external_request_spec.rb
+++ b/spec/external_request_spec.rb
@@ -3,9 +3,18 @@ require 'spec_helper'
 describe 'External request', :vcr => true do
   it 'queries FactoryGirl contributors on Github' do
     uri = URI('https://api.github.com/repos/thoughtbot/factory_girl/contributors')
+    response = do_request(uri)
 
-    response = Net::HTTP.get(uri)
+    expect(response).to be_an_instance_of(Net::HTTPOK)
+  end
 
-    expect(response).to be_an_instance_of(String)
+  def do_request(uri)
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true
+    http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+
+    request = Net::HTTP::Get.new(uri.request_uri)
+
+    http.request(request)
   end
 end


### PR DESCRIPTION
Fixes problems I found trying to follow the tutorial. Fixes #1.
- Does an HTTPS request instead of HTTP.
- Extracts all the request logic to a helper **do_request**
